### PR TITLE
Add minimal full-stack FIX exchange simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Fix-exchange-simulator
+# Fix Exchange Simulator
+
+This project provides a minimal end-to-end FIX exchange simulator. It exposes an HTTP API for submitting buy/sell orders and serves a simple web UI for manual testing.
+
+## Features
+
+- Node.js backend with in-memory order book and matching engine
+- REST-like endpoints to submit orders and retrieve the current book
+- Static HTML/JavaScript frontend served from the same server
+- Simple test script verifying basic matching behaviour
+- Dockerfile for containerized deployment
+
+## Running locally
+
+```bash
+npm start
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Testing
+
+```bash
+npm test
+```
+
+## Deploying to AWS
+
+1. **Backend**: Build the Docker image and push to Amazon ECR, then run on ECS or another service:
+   ```bash
+   docker build -t fix-simulator .
+   docker run -p 3000:3000 fix-simulator
+   ```
+   In AWS, expose port 3000 or configure a load balancer.
+
+2. **Frontend**: The static files are served by the Node.js server. If you prefer separate hosting, upload the contents of `public/` to Amazon S3 and configure the backend API endpoint accordingly.
+
+This repository is a starting point for more advanced FIX protocol simulations or integrations.

--- a/orderBook.js
+++ b/orderBook.js
@@ -1,0 +1,57 @@
+class OrderBook {
+  constructor() {
+    this.buys = [];
+    this.sells = [];
+  }
+
+  addOrder(order) {
+    const { type, price, quantity } = order;
+    if (!['buy', 'sell'].includes(type)) {
+      throw new Error('Invalid order type');
+    }
+    if (typeof price !== 'number' || typeof quantity !== 'number') {
+      throw new Error('Price and quantity must be numbers');
+    }
+    const trades = [];
+    if (type === 'buy') {
+      this.sells.sort((a, b) => a.price - b.price);
+      while (order.quantity > 0 && this.sells.length && this.sells[0].price <= price) {
+        const best = this.sells[0];
+        const qty = Math.min(order.quantity, best.quantity);
+        trades.push({ price: best.price, quantity: qty });
+        order.quantity -= qty;
+        best.quantity -= qty;
+        if (best.quantity === 0) {
+          this.sells.shift();
+        }
+      }
+      if (order.quantity > 0) {
+        this.buys.push({ type, price, quantity: order.quantity });
+        this.buys.sort((a, b) => b.price - a.price);
+      }
+    } else {
+      this.buys.sort((a, b) => b.price - a.price);
+      while (order.quantity > 0 && this.buys.length && this.buys[0].price >= price) {
+        const best = this.buys[0];
+        const qty = Math.min(order.quantity, best.quantity);
+        trades.push({ price: best.price, quantity: qty });
+        order.quantity -= qty;
+        best.quantity -= qty;
+        if (best.quantity === 0) {
+          this.buys.shift();
+        }
+      }
+      if (order.quantity > 0) {
+        this.sells.push({ type, price, quantity: order.quantity });
+        this.sells.sort((a, b) => a.price - b.price);
+      }
+    }
+    return { trades, book: this.getState() };
+  }
+
+  getState() {
+    return { buys: this.buys, sells: this.sells };
+  }
+}
+
+module.exports = OrderBook;

--- a/orderBook.test.js
+++ b/orderBook.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const OrderBook = require('./orderBook');
+
+const book = new OrderBook();
+book.addOrder({ type: 'sell', price: 100, quantity: 5 });
+const result = book.addOrder({ type: 'buy', price: 110, quantity: 3 });
+assert.deepStrictEqual(result.trades, [{ price: 100, quantity: 3 }]);
+assert.deepStrictEqual(book.getState(), {
+  buys: [],
+  sells: [{ type: 'sell', price: 100, quantity: 2 }],
+});
+console.log('All tests passed');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fix-exchange-simulator",
+  "version": "1.0.0",
+  "description": "Simple FIX exchange simulator with order book and UI",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node orderBook.test.js"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,24 @@
+async function fetchBook() {
+  const res = await fetch('/orders');
+  const book = await res.json();
+  document.getElementById('book').textContent = JSON.stringify(book, null, 2);
+}
+
+document.getElementById('order-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const order = {
+    type: form.type.value,
+    price: parseFloat(form.price.value),
+    quantity: parseInt(form.quantity.value, 10),
+  };
+  await fetch('/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(order),
+  });
+  form.reset();
+  fetchBook();
+});
+
+fetchBook();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Fix Exchange Simulator</title>
+</head>
+<body>
+  <h1>Fix Exchange Simulator</h1>
+  <form id="order-form">
+    <label>Type:
+      <select name="type">
+        <option value="buy">Buy</option>
+        <option value="sell">Sell</option>
+      </select>
+    </label>
+    <label>Price: <input name="price" type="number" step="0.01" required /></label>
+    <label>Quantity: <input name="quantity" type="number" required /></label>
+    <button type="submit">Submit</button>
+  </form>
+  <h2>Order Book</h2>
+  <pre id="book"></pre>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+const OrderBook = require('./orderBook');
+
+const orderBook = new OrderBook();
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  if (req.method === 'GET' && parsed.pathname === '/orders') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(orderBook.getState()));
+  } else if (req.method === 'POST' && parsed.pathname === '/orders') {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      try {
+        const order = JSON.parse(body);
+        const result = orderBook.addOrder(order);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+  } else {
+    let filePath = path.join(
+      __dirname,
+      'public',
+      parsed.pathname === '/' ? 'index.html' : parsed.pathname
+    );
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+      const ext = path.extname(filePath);
+      const contentType = ext === '.js' ? 'application/javascript' : 'text/html';
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    });
+  }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- Implement simple Node.js server exposing `/orders` API and serving static frontend
- Add in-memory order book with basic matching algorithm and corresponding UI
- Provide Dockerfile, test script, and AWS deployment instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6246713c833281b68a9b1ab91e2b